### PR TITLE
Dispatched events when dialog box is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.0 2020-08-26
+
+- Dispatched events when dialog box is opened whether automatically or manually.
+
 ### 1.0.7 2020-08-12
 
 - Fixes an issue that prevented use of `beforeCkeditorInline` overrides at project level.

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ All you need to do to trigger a dialog box from custom widgets or UI is add a da
 ### Listening to events for analytics
 
 2 events are triggered on dialog-box opening:
-- `isTimeTriggered` for automatically opened dialog box on page load
-- `isOpened` for every opened dialog box
+- `time-triggered` for automatically opened dialog box on page load
+- `opened` for every opened dialog box
 
 A dialog opening on page load will trigger the 2 events, and a manually clicked link opening a dialog box will trigger only the latter.
 
@@ -100,8 +100,10 @@ These events are dispatched on the page `body`. Therefore, event listeners can b
 Example of listener to add at project level:
 
 ```js
-var body = document.querySelector('body');
-body.addEventListener('isTimeTriggered', function (evt) {
+document.body.addEventListener('apostrophe-dialog-box:time-triggered', function (evt) {
+  // code for `evt` handling
+}, false);
+document.body.addEventListener('apostrophe-dialog-box:opened', function (evt) {
   // code for `evt` handling
 }, false);
 ```

--- a/README.md
+++ b/README.md
@@ -87,6 +87,26 @@ All you need to do to trigger a dialog box from custom widgets or UI is add a da
 
 ![Copy to clipboard](/images/clipboard.png)
 
+### Listening to events for analytics
+
+2 events are triggered on dialog-box opening:
+- `isTimeTriggered` for automatically opened dialog box on page load
+- `isOpened` for every opened dialog box
+
+A dialog opening on page load will trigger the 2 events, and a manually clicked link opening a dialog box will trigger only the latter.
+
+These events are dispatched on the page `body`. Therefore, event listeners can be added to be notified. It can be useful for analytics purposes.
+
+Example of listener to add at project level:
+
+```js
+var body = document.querySelector('body');
+body.addEventListener('isTimeTriggered', function (evt) {
+  // code for `evt` handling
+}, false);
+```
+
+
 ## Extending and Customizing Dialog Boxes
 
 You'll probably want to customize and potentially have multiple Dialog Box templates to choose from. In these custom templates you can include projet-level widgets, markup, and CSS.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ document.body.addEventListener('apostrophe-dialog-box:opened', function (evt) {
 }, false);
 ```
 
+The event emitted contains the dialog box id `dialogId` in order to distinguish between multiple dialog boxes on a page.
 
 ## Extending and Customizing Dialog Boxes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-dialog-box",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "`apostrophe-dialog-box` provides simple pop-up dialog boxes for your Apostrophe site. Manage them you would like any other piece type, edit their content in-context, provide your own templates, and have users trigger them with various configuration.",
   "main": "index.js",
   "directories": {

--- a/public/js/always.js
+++ b/public/js/always.js
@@ -17,6 +17,8 @@
     clipboard: '[data-apos-dialog-box-copy-to-clipboard]'
   };
 
+  var body = document.querySelector('body');
+
   var helpers = {
     closeDialog: function(event) {
       if (event.target.classList.contains(dialogClasses.active)) {
@@ -127,6 +129,9 @@
     };
 
     this.open = function () {
+      var event = document.createEvent('Event');
+      event.initEvent('isOpened', true, true);
+      body.dispatchEvent(event);
       return this.element().classList.add(dialogClasses.active);
     };
 
@@ -188,6 +193,10 @@
         dialogs.close();
         render.render(dialog.id, function() {
           dialog.open();
+
+          var event = document.createEvent('Event');
+          event.initEvent('isTimeTriggered', true, true);
+          body.dispatchEvent(event);
         });
         clearTimeout(triggerTimeout);
       }, triggerTime);

--- a/public/js/always.js
+++ b/public/js/always.js
@@ -17,8 +17,6 @@
     clipboard: '[data-apos-dialog-box-copy-to-clipboard]'
   };
 
-  var body = document.querySelector('body');
-
   var helpers = {
     closeDialog: function(event) {
       if (event.target.classList.contains(dialogClasses.active)) {
@@ -129,9 +127,9 @@
     };
 
     this.open = function () {
-      var event = document.createEvent('Event');
-      event.initEvent('isOpened', true, true);
-      body.dispatchEvent(event);
+      apos.utils.emit(document.body, 'apostrophe-dialog-box:opened', {
+        dialogId: this.id
+      });
       return this.element().classList.add(dialogClasses.active);
     };
 
@@ -193,10 +191,9 @@
         dialogs.close();
         render.render(dialog.id, function() {
           dialog.open();
-
-          var event = document.createEvent('Event');
-          event.initEvent('isTimeTriggered', true, true);
-          body.dispatchEvent(event);
+          apos.utils.emit(document.body, 'apostrophe-dialog-box:time-triggered', {
+            dialogId: dialog.id
+          });
         });
         clearTimeout(triggerTimeout);
       }, triggerTime);


### PR DESCRIPTION
To be able to track the opening of the popin when it is triggered, 2 events are triggered:
- `isTimeTriggered` for automatically opened dialog box on page load
- `isOpened` for every opened dialog box

## How to test

- Clone and install `dialog-sandbox` project from Apostrophe, `npm link` apostrophe-dialog-box with dialog-sandbox. 
- Add this in `lib/modules/apostrophe-assets/public/js/site.js` in dialog-sandbox, then `npm start`
```js
  document.body.addEventListener('apostrophe-dialog-box:time-triggered', function (e) {
     console.log('e ====> ', e)
  }, false);
  document.body.addEventListener('apostrophe-dialog-box:opened', function (e) {
     console.log('e ====> ', e)
  }, false);
```
- Configure a dialog box on page load, and events should be logged in browser's console.