### PR TITLE
Replace xhr by apos.utils.get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.8 2020-12-09
+
+- Replaces XHR call by `apos.utils.get` to respect locale prefix when used with apostrophe-workflow.
+
 ### 1.0.7 2020-08-12
 
 - Fixes an issue that prevented use of `beforeCkeditorInline` overrides at project level.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-dialog-box",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "`apostrophe-dialog-box` provides simple pop-up dialog boxes for your Apostrophe site. Manage them you would like any other piece type, edit their content in-context, provide your own templates, and have users trigger them with various configuration.",
   "main": "index.js",
   "directories": {

--- a/public/js/always.js
+++ b/public/js/always.js
@@ -139,25 +139,23 @@
     var _element = document.getElementById(id);
 
     this.render = function(dialogId, callback) {
-      var http = new window.XMLHttpRequest();
-
-      http.onreadystatechange = function() {
-        if (this.readyState === 4 && this.status === 200) {
-          _element.innerHTML = this.responseText;
-          if (apos.emit) {
-            apos.emit('enhance', window.$(_element));
-          } else {
-            apos.utils.runPlayers(_element);
-          }
-          if (callback) {
-            callback();
-          }
+      apos.utils.get('/modules/apostrophe-dialog-box/render/' + dialogId, {}, function (err, response) {
+        if (err) {
+          return;
         }
-      };
 
-      http.open('GET', '/modules/apostrophe-dialog-box/render/' + dialogId, true);
+        _element.innerHTML = response;
 
-      http.send();
+        if (apos.emit) {
+          apos.emit('enhance', window.$(_element));
+        } else {
+          apos.utils.runPlayers(_element);
+        }
+
+        if (callback) {
+          callback();
+        }
+      });
     };
   }
 


### PR DESCRIPTION
Shyam from Michelin noticed the XHR function does not respect prefix in locales, but `apos.utils.get` does and dialog boxes are displayed correctly.

This PR therefore replaces XHR by `apos.utils.get`. Can we consider `apos.utils.get` will always be present?