### PR TITLE
Add closed event

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   "extends": "apostrophe",
   "ignorePatterns": [
     "public/js/ckeditorPlugins/"
-  ]
+  ],
+  "rules": {
+    "no-var": 0
+  }
 }

--- a/package.json
+++ b/package.json
@@ -24,21 +24,21 @@
   "author": "Apostrophe Technologies",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-apostrophe": "^3.1.0",
-    "eslint-config-standard": "^14.1.0",
-    "eslint-plugin-import": "^2.20.1",
-    "eslint-plugin-node": "^11.0.0",
-    "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.1",
-    "stylelint": "^9.10.1",
-    "stylelint-config-punkave": "0.0.9",
-    "stylelint-order": "^2.2.1"
+    "eslint": "^7.20.0",
+    "eslint-config-apostrophe": "^3.4.1",
+    "eslint-config-standard": "^16.0.2",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^4.3.1",
+    "eslint-plugin-standard": "^4.1.0",
+    "stylelint": "^13.11.0",
+    "stylelint-config-punkave": "1.1.3",
+    "stylelint-order": "^4.1.0"
   },
   "dependencies": {
     "bluebird": "^3.7.2",
-    "lodash": "^4.17.15",
-    "sanitize-html": "^1.20.1"
+    "lodash": "^4.17.21",
+    "sanitize-html": "^2.3.2"
   },
   "bugs": {
     "url": "https://github.com/apostrophecms/apostrophe-dialog-box/issues"

--- a/public/js/always.js
+++ b/public/js/always.js
@@ -12,7 +12,7 @@
     closeIcon: 'apos-dialog-box-close-icon'
   };
 
-  var dialogAttrubutes = {
+  var dialogAttributes = {
     buttons: '[data-apos-dialog-box-trigger]',
     clipboard: '[data-apos-dialog-box-copy-to-clipboard]'
   };
@@ -221,27 +221,22 @@
     };
   }
 
-  extend(TimeTrigger, Trigger);
-
   function Dialogs() {
     var _markups = document.getElementsByClassName(dialogClasses.markups);
 
-    var _buttons = document.querySelectorAll(dialogAttrubutes.buttons);
+    var _buttons = document.querySelectorAll(dialogAttributes.buttons);
 
-    var _clipboards = document.querySelectorAll(dialogAttrubutes.clipboard);
+    var _clipboards = document.querySelectorAll(dialogAttributes.clipboard);
 
     var _render = new Renderer(dialogClasses.render);
 
-    var _triggers = [new TimeTrigger(_render, this)];
+    var _triggers = [ new TimeTrigger(_render, this) ];
 
     this.close = function() {
-      var dialogs = document.getElementsByClassName(dialogClasses.overlay);
-      for (var i = 0; i < dialogs.length; i++) {
-        var element = dialogs[i];
+      var dialogs = window.APOS_DIALOGS.dialogs;
 
-        if (element) {
-          element.classList.remove(dialogClasses.active);
-        }
+      for (var id in dialogs) {
+        dialogs[id].close();
       }
     };
 
@@ -253,32 +248,26 @@
             return function(event) {
               event.preventDefault();
 
-              var dialogId = button.getAttribute('data-apos-dialog-box-trigger');
+              var dialogId = button.dataset.aposDialogBoxTrigger;
 
               if (!dialogId) {
                 return;
               }
 
-              var exists = document.getElementById(dialogId);
+              var dialogElm = document.getElementById(dialogId);
 
               // If dialog exists then we don't need to render
-              if (exists) {
-                return new Dialog(dialogId, {
-                  disableSession: true
-                }).open();
+              if (dialogElm) {
+                return getDialog(dialogId, { disableSession: true }).open();
               }
 
               return _render.render(dialogId, function() {
-                var dialog = new Dialog(dialogId, {
-                  disableSession: true
-                });
-                dialog.open();
+                getDialog(dialogId, { disableSession: true }).open();
 
                 // enhance the new areas
                 if (apos.emit) {
                   apos.emit('enhance', $('#apostrophe-dialog-box-render-area'));
                 }
-
               });
             };
           })(_buttons[i])
@@ -288,7 +277,8 @@
 
     this.initDialogs = function() {
       for (var i = 0; i < _markups.length; i++) {
-        var dialog = new Dialog(_markups[i].getAttribute('data-id'));
+        var dialog = getDialog(_markups[i].dataset.id);
+
         for (var j = 0; j < _triggers.length; j++) {
           if (_triggers[j].canActivate(dialog)) {
             (function(dialogInstance) {

--- a/public/js/always.js
+++ b/public/js/always.js
@@ -185,22 +185,12 @@
     };
   }
 
-  function Trigger(render, dialogs) {
-    this._type = '';
+  function TimeTrigger(render, dialogs) {
+    this._type = 'time';
 
     this.getType = function() {
       return this._type;
     };
-
-    this.canActivate = function(dialog) {
-      return false;
-    };
-
-    this.addListeners = function(dialog) {};
-  }
-
-  function TimeTrigger(render, dialogs) {
-    this._type = 'time';
 
     this.canActivate = function(dialog) {
       return !!dialog.time && dialog.checkSession();
@@ -210,12 +200,12 @@
       var triggerTime = dialog.time * 1000;
       var triggerTimeout = setTimeout(function() {
         dialogs.close();
+
         render.render(dialog.id, function() {
           dialog.open();
-          apos.utils.emit(document.body, 'apostrophe-dialog-box:time-triggered', {
-            dialogId: dialog.id
+          triggerEvent('time-triggered', dialog.id);
           });
-        });
+
         clearTimeout(triggerTimeout);
       }, triggerTime);
     };

--- a/public/js/always.js
+++ b/public/js/always.js
@@ -17,20 +17,6 @@
     clipboard: '[data-apos-dialog-box-copy-to-clipboard]'
   };
 
-  var helpers = {
-    closeDialog: function(event) {
-      if (event.target.classList.contains(dialogClasses.active)) {
-        event.target.classList.remove(dialogClasses.active);
-      }
-
-      if (event.target.classList.contains(dialogClasses.closeIcon)) {
-        event.target
-          .closest('.' + dialogClasses.active)
-          .classList.remove(dialogClasses.active);
-      }
-    }
-  };
-
   function extend(Child, Parent) {
     var Temp = function() {};
 
@@ -120,7 +106,15 @@
       }
 
       if (_element) {
-        _element.addEventListener('click', helpers.closeDialog);
+        var self = this;
+
+        _element.addEventListener('click', function (event) {
+          var cns = event.target.classList;
+          var isActiveDialog = cns.contains(dialogClasses.active);
+          var isCloseButton = cns.contains(dialogClasses.closeIcon);
+
+          (isActiveDialog || isCloseButton) && self.close();
+        });
       }
 
       return _element;
@@ -130,10 +124,15 @@
       apos.utils.emit(document.body, 'apostrophe-dialog-box:opened', {
         dialogId: this.id
       });
+
       return this.element().classList.add(dialogClasses.active);
     };
 
     this.close = function() {
+      apos.utils.emit(document.body, 'apostrophe-dialog-box:closed', {
+        dialogId: this.id
+      });
+
       return this.element().classList.remove(dialogClasses.active);
     };
   }

--- a/public/js/always.js
+++ b/public/js/always.js
@@ -2,8 +2,6 @@
 // It is inside a self-executing function to avoid leaks in the global namespace.
 
 (function() {
-  window.APOS_DIALOGS = { dialogs: {} };
-
   var dialogClasses = {
     markups: 'apostrophe-dialog-box-markup',
     render: 'apostrophe-dialog-box-render-area',
@@ -15,6 +13,12 @@
   var dialogAttributes = {
     buttons: '[data-apos-dialog-box-trigger]',
     clipboard: '[data-apos-dialog-box-copy-to-clipboard]'
+  };
+
+  window.APOS_DIALOGS = {
+    dialogs: {},
+    dialogClasses: dialogClasses,
+    dialogAttributes: dialogAttributes
   };
 
   function getDialog(id, options) {

--- a/public/js/always.js
+++ b/public/js/always.js
@@ -102,7 +102,11 @@
       _element = document.getElementById(id);
 
       if (!_element) {
-        _element = document.getElementById(dialogClasses.render).firstElementChild;
+        var renderElm = document.getElementById(dialogClasses.render);
+
+        if (renderElm) {
+          _element = renderElm.firstElementChild;
+      }
       }
 
       if (_element) {
@@ -309,7 +313,8 @@
     dialogs.initCopyToClipboards();
 
     document.addEventListener('keyup', function(event) {
-      if (event.keyCode === 27) {
+      // NOTE: "keyCode" is deprecated but needed for old browsers
+      if (event.key === 'Escape' || event.keyCode === 27) {
         dialogs.close();
       }
     });

--- a/public/js/always.js
+++ b/public/js/always.js
@@ -45,15 +45,15 @@
     this._markup = document.getElementById('markup:' + id);
 
     this.time = this._markup
-      ? parseInt(this._markup.getAttribute('data-time'))
+      ? parseInt(this._markup.dataset.time)
       : null;
 
     this.session = this._markup
-      ? this._markup.getAttribute('data-session') === '1'
+      ? this._markup.dataset.session === '1'
       : false;
 
     this.sessionTime = this._markup
-      ? this._markup.getAttribute('data-session-time')
+      ? this._markup.dataset.sessionTime
       : null;
 
     this.id = id;
@@ -114,7 +114,7 @@
 
         if (renderElm) {
           _element = renderElm.firstElementChild;
-      }
+        }
       }
 
       if (_element) {
@@ -204,7 +204,7 @@
         render.render(dialog.id, function() {
           dialog.open();
           triggerEvent('time-triggered', dialog.id);
-          });
+        });
 
         clearTimeout(triggerTimeout);
       }, triggerTime);
@@ -287,7 +287,7 @@
             return function(event) {
               event.preventDefault();
               var el = document.createElement('textarea');
-              el.value = '<a href="#" data-apos-dialog-box-trigger="' + button.getAttribute('data-apos-dialog-box-copy-to-clipboard') + '">Launch Dialog</a>';
+              el.value = '<a href="#" data-apos-dialog-box-trigger="' + button.dataset.aposDialogBoxCopyToClipboard + '">Launch Dialog</a>';
               el.setAttribute('readonly', '');
               el.style.position = 'absolute';
               el.style.left = '-9999px';


### PR DESCRIPTION
Created as per discussed in #26 

So it started out simple by adding `'apostrophe-dialog-box:closed'` event to the `Dialog.close()` method, but since the closing of the Dialog was not generalized to this function, I had to make some adjustments to ensure that it was, so the event is triggered every time the dialog is closed.

However I also discovered several thing in the code that could cause errors to be raised, and I optimized some areas.
Feel free to look through it and don't hesitate to let me know if you need me to elaborate.

NB: I updated the linting, as I had problems installing since there was a ESLint version clash.