### PR TITLE
add trash to arrangeFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## next
+
+- add `trash` to `arrangeFields` to prevent warning during startup
+
 ## 1.2.0 (2021-03-24)
 
 - Adds a client side event on closing dialog boxes. Thanks to [Toke Voltelen](https://github.com/Tokimon) for the contribution.

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = {
       {
         name: 'admin',
         label: 'Admin',
-        fields: [ 'published', 'slug' ]
+        fields: [ 'published', 'slug', 'trash' ]
       }
     ]);
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

During startup, apostrophe will display the following warning:

```
⚠️ doc type apostrophe-dialog-box contains unarranged field(s): trash.                                                                                                          
Arrange all of your fields with arrangeFields, using meaningful group labels.
https://apos.dev/arrange-fields
```

We extends `apostrophe-pieces` which contains the `trash` field but we forgot to put it inside the `arrangeFields` section.

## What are the specific steps to test this change?

1. Start apostrophe e.g. `npm start`
2. Check `stdout` for warnings

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] ~~Related documentation has been updated~~
- [ ] ~~Related tests have been updated~~

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
